### PR TITLE
corrige url e método para retentativa de pagamento

### DIFF
--- a/src/Prettus/Moip/Subscription/Resources/Invoices.php
+++ b/src/Prettus/Moip/Subscription/Resources/Invoices.php
@@ -72,12 +72,12 @@ class Invoices {
      */
     public function retryPayment($code, array $options = []){
 
-        $url = $this->interpolate( self::BASE_PATH."/{code}/payments", [
+        $url = $this->interpolate( self::BASE_PATH."/{code}/retry", [
             'version'   => $this->client->getApiVersion(),
             'resource'  => self::RESOURCE,
             'code'      => $code
         ]);
 
-        return $this->client->get($url, $options);
+        return $this->client->post($url, $options);
     }
 }


### PR DESCRIPTION
o metodo retryPayment estava com a chamada do endpoint incorreta, a chamada correta é um post para /assinaturas/v1/invoices/{id}/retry